### PR TITLE
Accept OpenWebUI/Cohere-style rerank payloads; normalize documents an…

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,14 @@ curl -X POST "http://localhost:9000/api/v1/rerank/"
   -d '{"query": "machine learning", "passages": ["AI is cool", "Dogs are pets", "MLX is fast"]}'
 ```
 
+Note: The native rerank endpoint also accepts Cohere/OpenWebUI-style payloads using `documents` instead of `passages` and `top_n` instead of `top_k`:
+
+```bash
+curl -X POST "http://localhost:9000/api/v1/rerank/" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "machine learning", "documents": ["AI is cool", "Dogs are pets", "MLX is fast"], "top_n": 3}'
+```
+
 ---
 
 ## 🧪 Performance Testing & Validation


### PR DESCRIPTION
…d top_n/top_k; docs

Fixes a 422 on /api/v1/rerank/ when clients (e.g., OpenWebUI) send {query, documents:[...]} instead of {passages:[...]}. Adds input normalization in models so both styles are accepted without breaking existing clients.

Changes:
- app/models/requests.py: Add model-level pre-validation to map documents -> passages and top_n -> top_k; support documents as list[str] or list[{text:...}]. Keeps existing validation and behavior intact.
- app/models/cohere_models.py: Normalize Cohere request payloads to accept string or object documents (text/content/body/value) and map top_k -> top_n. No router changes required.
- README.md: Document that native /api/v1/rerank/ now accepts {documents: [...]} and {top_n} as aliases for {passages} and {top_k}.

Notes:
- Backward compatible: clients using passages/top_k remain unaffected.
- Cohere endpoints (/v1/rerank, /v2/rerank) already used documents; normalization now also accepts object documents and top_k alias.
- Tests: Provided diagnosis and suggestions to harden tests/test_cohere_api.py (readiness polling, httpx, timeouts), but no test code changes included in this commit.