### PR TITLE
OpenAI compatibility: add base64 embedding encoding + optional dimens…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.2.0] - 2025-09-10
+ 
+## [1.2.3] - 2025-10-30
+
+### Added
+- OpenAI compatibility: base64 encoding support via `encoding_format="base64"` for `/v1/embeddings`.
+- OpenAI compatibility: optional `dimensions` handling (truncate/pad to requested size).
+
+### Documentation
+- README: Added LightRAG integration note (OpenAI embeddings + Cohere reranking tested successfully).
+- README: Added Qwen Embedding similarity scaling note and recommended starting threshold `COSINE_THRESHOLD=0.0` for LightRAG.
+- README: Example for requesting base64-encoded embeddings and decoding back to float32.
+
+### Notes
+- These updates maintain full compatibility with existing OpenAI SDK usage; default remains `encoding_format="float"`.
+
 
 ### Added
 - 🆕 **Cohere API v1/v2 Compatibility**: Full support for Cohere reranking API

--- a/README.md
+++ b/README.md
@@ -274,6 +274,31 @@ response = client.embeddings.create(
     model="text-embedding-ada-002"
 )
 # 🚀 10x faster than OpenAI, same code!
+
+"""
+Base64 encoding support
+-----------------------
+
+For OpenAI-compatible calls, you can request base64-encoded embeddings by setting `encoding_format` to `"base64"`. This is useful when transporting vectors through systems that expect strings only.
+
+Example (Python OpenAI SDK):
+
+```python
+response = client.embeddings.create(
+    input=["Hello world"],
+    model="text-embedding-ada-002",
+    encoding_format="base64",  # returns base64-encoded float32 bytes
+)
+
+# embedding string is base64; decode if you need floats again
+import base64, numpy as np
+arr = np.frombuffer(base64.b64decode(response.data[0].embedding), dtype=np.float32)
+```
+
+Notes:
+- `encoding_format` defaults to `"float"` (list[float]).
+- `dimensions` is accepted and will truncate/pad to the requested size when supported.
+"""
 ```
 
 ### TEI Compatible
@@ -310,6 +335,25 @@ response = requests.post("http://localhost:9000/v1/rerank", json={
     "top_n": 2
 })
 ```
+
+---
+
+## 🧩 LightRAG Integration
+
+We validated an end-to-end workflow using LightRAG with this service:
+- Embeddings via the OpenAI-compatible endpoint (`/v1/embeddings`)
+- Reranking via the Cohere-compatible endpoint (`/v1/rerank` or `/v2/rerank`)
+
+Results: the integration tests succeeded using OpenAI embeddings and Cohere reranking.
+
+Qwen Embedding similarity scaling note: when using the Qwen Embedding model, we observed cosine similarity values that appear very small (e.g., `0.02`, `0.03`). This is expected due to vector scaling differences and does not indicate poor retrieval by itself. As a starting point, we recommend disabling the retrieval threshold in LightRAG to avoid filtering out good matches prematurely:
+
+```
+# === Retrieval threshold ===
+COSINE_THRESHOLD=0.0
+```
+
+Adjust upward later based on your dataset and evaluation results.
 
 ### Native API
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,7 @@ This package provides FastAPI-based REST endpoints for:
 - Apple Silicon MLX optimization with PyTorch fallback
 - Multi-API compatibility: Native, OpenAI, TEI, and Cohere formats
 
-🚀 NEW in v1.2.2: Fully resolved API compatibility test warnings!
+🚀 NEW in v1.2.3: OpenAI base64 encoding support + docs update
 - Fixed Cohere API tests with proper environment variable handling
 - Resolved pytest environment variable propagation issues
 - Eliminated false warnings while maintaining 100% API compatibility
@@ -17,5 +17,5 @@ This package provides FastAPI-based REST endpoints for:
 Author: joonsoo-me
 """
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 __author__ = "joonsoo-me"


### PR DESCRIPTION
### Added
- OpenAI compatibility: base64 encoding support via `encoding_format="base64"` for `/v1/embeddings`.
- OpenAI compatibility: optional `dimensions` handling (truncate/pad to requested size).

### Documentation
- README: Added LightRAG integration note (OpenAI embeddings + Cohere reranking tested successfully).
- README: Added Qwen Embedding similarity scaling note and recommended starting threshold `COSINE_THRESHOLD=0.0` for LightRAG.
- README: Example for requesting base64-encoded embeddings and decoding back to float32.

### Notes
- These updates maintain full compatibility with existing OpenAI SDK usage; default remains `encoding_format="float"`.