### PR TITLE
fix: remove score validation bounds to support raw logits from cross-encoder

### DIFF
--- a/app/models/responses.py
+++ b/app/models/responses.py
@@ -39,7 +39,8 @@ class EmbedResponse(BaseModel):
     """Response model for embedding generation."""
 
     model_config = ConfigDict(
-        json_encoders={datetime: lambda v: v.isoformat()}, protected_namespaces=()  # Allow model_ fields
+        json_encoders={datetime: lambda v: v.isoformat()},
+        protected_namespaces=(),  # Allow model_ fields
     )
 
     # Enhanced structure with both new format and backward compatibility
@@ -74,9 +75,7 @@ class RerankResult(BaseModel):
     )
     score: float = Field(
         ...,
-        description="Relevance score (higher is more relevant, can be negative for similarity methods)",
-        ge=-1.0,
-        le=1.0,
+        description="Relevance score (higher is more relevant, raw logits from model or normalized based on client request)",
         json_schema_extra={"example": 0.8542},
     )
     index: int = Field(..., description="Original index in input list", ge=0, json_schema_extra={"example": 0})
@@ -86,7 +85,8 @@ class RerankResponse(BaseModel):
     """Response model for document reranking."""
 
     model_config = ConfigDict(
-        json_encoders={datetime: lambda v: v.isoformat()}, protected_namespaces=()  # Allow model_ fields
+        json_encoders={datetime: lambda v: v.isoformat()},
+        protected_namespaces=(),  # Allow model_ fields
     )
 
     results: List[RerankResult] = Field(


### PR DESCRIPTION
## Summary

- Fixes validation error when using cross-encoder models that return raw logits (e.g., `ms-marco-MiniLM-L-6-v2`)
- Removes artificial `-1.0` to `1.0` constraint on rerank scores that was blocking legitimate model outputs

## Problem

The current code enforces score bounds (`ge=-1.0, le=1.0`) in `RerankResult`, which causes validation errors with standard cross-encoder models that output raw logits (e.g., scores like `7.45` or `-2.3`). This breaks reranking functionality with industry-standard models.

## Solution

- Remove `ge=-1.0, le=1.0` constraints from `RerankResult.score` field
- Allow models to return their natural output format (raw logits)
- Normalization (sigmoid) is already handled at the router layer when `OPENAI_RERANK_AUTO_SIGMOID=true`

## Testing

Tested with `cross-encoder/ms-marco-MiniLM-L-6-v2` on macOS Apple Silicon:
- Before: Validation error on scores > 1.0
- After: Scores pass validation, normalization applied correctly at router level

## Impact

- Unblocks compatibility with most sentence-transformers cross-encoder models
- Restores documented behavior of auto-sigmoid feature
- No breaking changes (only removes overly restrictive validation)