### PR TITLE
Issue #18: LightRAG option parity (embedding token limit, dimensions gate, Cohere rerank chunking)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,12 @@ MODEL_PATH=
 DIMENSION_STRATEGY=hidden_size
 # OUTPUT_EMBEDDING_DIMENSION=2560  # uncomment + set DIMENSION_STRATEGY=pad_or_truncate to force a fixed size
 
+# LightRAG parity (OpenAI-compatible embeddings):
+# - EMBEDDING_SEND_DIM controls whether /v1/embeddings honors the `dimensions` request field.
+# - EMBEDDING_TOKEN_LIMIT is an alias for DEFAULT_MAX_TOKENS_OVERRIDE (sets a default per-text token budget).
+# EMBEDDING_SEND_DIM=true
+# EMBEDDING_TOKEN_LIMIT=4096
+
 # =========================
 # Performance (Embeddings)
 # =========================
@@ -60,6 +66,11 @@ RERANK_SCORE_NORM=none
 # Automatically apply sigmoid normalization for OpenAI-compatible rerank scores
 # true | false (default true)
 OPENAI_RERANK_AUTO_SIGMOID=true
+
+# Cohere-compatible rerank chunking (LightRAG parity)
+# Useful for rerank models with strict token limits (e.g., ColBERT-style).
+# RERANK_ENABLE_CHUNKING=false
+# RERANK_MAX_TOKENS_PER_DOC=480
 
 # =========================
 # Model Cache & Storage

--- a/README.md
+++ b/README.md
@@ -111,10 +111,17 @@ curl -s http://localhost:9000/api/v1/rerank/ \
 
 ```bash
 cat >> .env <<'ENV'
+# Torch cross-encoder (stable)
 RERANKER_BACKEND=auto
-RERANKER_MODEL_ID=cross-encoder/ms-marco-MiniLM-L-6-v2  # Torch (stable)
-# MLX experimental v1 also available: vserifsaglam/Qwen3-Reranker-4B-4bit-MLX
+RERANKER_MODEL_ID=cross-encoder/ms-marco-MiniLM-L-6-v2
+
+# MLX reranker (Apple Silicon). Required for MLX models:
+# RERANKER_BACKEND=mlx
+# RERANKER_MODEL_NAME=vserifsaglam/Qwen3-Reranker-4B-4bit-MLX
 ENV
+
+# Optional: pre-download the MLX reranker to the default HF cache
+# ./download-rerank-model.sh
 
 # Restart server, then call Native or OpenAI-compatible rerank
 curl -s http://localhost:9000/api/v1/rerank/ \
@@ -137,6 +144,7 @@ Notes
 - OpenAI drop-in supported for both embeddings and rerank (/v1/embeddings, /v1/rerank). See docs for a tiny SDK example.
 - Scores may be auto‑sigmoid‑normalized for OpenAI clients by default (disable via `OPENAI_RERANK_AUTO_SIGMOID=false`).
 - The root endpoint `/` shows both `embedding_dimension` (served) and `hidden_size` (model config) for clarity.
+- Reranker backend `auto` defaults to Torch for compatibility; MLX reranker models require `RERANKER_BACKEND=mlx`.
 
 Run the full validation suite
 ```bash

--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ print(rr.get("results", rr))
 | ✅ | [**Kilo Code**](https://kilocode.ai/) | `Embed` |
 ###### We are waiting for your reports!
 
+### LightRAG Option Parity
+- `EMBEDDING_SEND_DIM`: gate honoring OpenAI-compatible `dimensions` in `/v1/embeddings`
+- `EMBEDDING_TOKEN_LIMIT`: alias for `DEFAULT_MAX_TOKENS_OVERRIDE` (default per-text token budget)
+- `RERANK_ENABLE_CHUNKING`, `RERANK_MAX_TOKENS_PER_DOC`: Cohere-compatible rerank document chunking
+- When unset, defaults remain unchanged.
+
 ## 📄 License
 
 MIT License – build amazing things locally.

--- a/app/config.py
+++ b/app/config.py
@@ -103,10 +103,36 @@ class Settings(BaseSettings):
         default="smart_truncate", description="Default truncation strategy"
     )
     default_max_tokens_override: Optional[int] = Field(
-        default=None, description="Default max tokens override (None = use model default)"
+        default=None,
+        description="Default max tokens override (None = use model default)",
+        validation_alias=AliasChoices(
+            "EMBEDDING_TOKEN_LIMIT",  # LightRAG parity
+            "DEFAULT_MAX_TOKENS_OVERRIDE",
+            "default_max_tokens_override",
+        ),
     )
     default_return_processing_info: bool = Field(
         default=False, description="Default setting for returning processing information"
+    )
+
+    # LightRAG parity: gate whether to honor OpenAI-compatible `dimensions` request field
+    embedding_send_dim: bool = Field(
+        default=True,
+        description="Whether to honor OpenAI-compatible `dimensions` field in /v1/embeddings",
+        validation_alias=AliasChoices("EMBEDDING_SEND_DIM", "embedding_send_dim"),
+    )
+
+    # LightRAG parity: Cohere rerank chunking configuration
+    rerank_enable_chunking: bool = Field(
+        default=False,
+        description="Enable document chunking for Cohere-compatible rerank endpoints (/v1|/v2/rerank)",
+        validation_alias=AliasChoices("RERANK_ENABLE_CHUNKING", "rerank_enable_chunking"),
+    )
+    rerank_max_tokens_per_doc: int = Field(
+        default=4096,
+        ge=1,
+        description="Max tokens per document when rerank chunking is enabled (approximate, 1 token ~= 4 chars)",
+        validation_alias=AliasChoices("RERANK_MAX_TOKENS_PER_DOC", "rerank_max_tokens_per_doc"),
     )
 
     # Logging
@@ -164,6 +190,14 @@ class Settings(BaseSettings):
         """Treat empty-string values for optional int fields as None to avoid validation errors."""
         if isinstance(v, str) and v.strip() == "":
             return None
+        return v
+
+    @field_validator("rerank_max_tokens_per_doc", mode="before")
+    @classmethod
+    def empty_string_rerank_max_tokens_to_default(cls, v):
+        """Treat empty-string values for rerank_max_tokens_per_doc as unset (use default)."""
+        if isinstance(v, str) and v.strip() == "":
+            return 4096
         return v
 
     @field_validator("batch_size", "max_batch_size")

--- a/app/main.py
+++ b/app/main.py
@@ -115,6 +115,11 @@ async def lifespan(app: FastAPI):
                 health_router.set_reranker_backend_manager(reranker_backend_manager)
                 # Expose reranker in OpenAI compatibility router
                 openai_router.set_reranker_backend_manager(reranker_backend_manager)
+                # Expose reranker in Cohere compatibility router
+                try:
+                    cohere_router.set_reranker_backend_manager(reranker_backend_manager)
+                except Exception:
+                    pass
                 logger.info(
                     "✅ Reranker backend ready",
                     backend=rerank_backend.__class__.__name__,

--- a/app/routers/cohere_router.py
+++ b/app/routers/cohere_router.py
@@ -11,10 +11,12 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
 
 from ..backends.base import BackendManager
+from ..config import settings
 from ..models.cohere_models import CohereRerankRequest, CohereRerankResponse, CohereRerankResult, CohereDocument
 from ..models.requests import RerankRequest
 from ..models.responses import ErrorResponse
 from ..services.reranking_service import RerankingService
+from ..utils.rerank_chunking import aggregate_scores, chunk_documents
 
 
 router = APIRouter(
@@ -43,12 +45,19 @@ def _filter_none_values(data):
 
 # This will be set by the main app
 _backend_manager: BackendManager = None
+_reranker_backend_manager: BackendManager = None
 
 
 def set_backend_manager(manager: BackendManager):
     """Set the backend manager instance."""
     global _backend_manager
     _backend_manager = manager
+
+
+def set_reranker_backend_manager(manager: BackendManager):
+    """Set a dedicated reranker backend manager (cross-encoder) for Cohere-compatible endpoints."""
+    global _reranker_backend_manager
+    _reranker_backend_manager = manager
 
 
 async def get_backend_manager() -> BackendManager:
@@ -60,6 +69,9 @@ async def get_backend_manager() -> BackendManager:
 
 async def get_reranking_service(manager: BackendManager = Depends(get_backend_manager)) -> RerankingService:
     """Dependency to get the reranking service."""
+    # Prefer dedicated reranker backend if configured and ready
+    if _reranker_backend_manager is not None and _reranker_backend_manager.is_ready():
+        return RerankingService(_reranker_backend_manager)
     if not manager.is_ready():
         raise HTTPException(status_code=503, detail="Backend not ready. Please wait for model initialization.")
     return RerankingService(manager)
@@ -120,6 +132,48 @@ async def rerank_v1(request: CohereRerankRequest, service: RerankingService = De
     while gaining significant performance improvements on Apple Silicon.
     """
     try:
+        # Optional document chunking (LightRAG parity) for models with strict token limits.
+        if settings.rerank_enable_chunking:
+            original_docs = request.documents
+            chunked_docs, doc_indices = chunk_documents(
+                original_docs,
+                max_tokens=int(settings.rerank_max_tokens_per_doc),
+            )
+
+            # Guardrail: never exceed the server's configured passage limit.
+            if len(chunked_docs) > settings.max_passages_per_rerank:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Chunking produced {len(chunked_docs)} chunks which exceeds "
+                        f"MAX_PASSAGES_PER_RERANK={settings.max_passages_per_rerank}. "
+                        f"Reduce RERANK_MAX_TOKENS_PER_DOC or increase MAX_PASSAGES_PER_RERANK."
+                    ),
+                )
+
+            scores = await service.compute_relevance_scores(query=request.query, passages=chunked_docs)
+            aggregated = aggregate_scores(
+                scores=scores,
+                doc_indices=doc_indices,
+                num_docs=len(original_docs),
+                aggregation="max",
+            )
+
+            # Apply top_n at document level (post-aggregation).
+            top_n = request.top_n if request.top_n is not None else len(original_docs)
+            top_n = min(int(top_n), len(aggregated))
+
+            results: List[CohereRerankResult] = []
+            for doc_idx, score in aggregated[:top_n]:
+                item = CohereRerankResult(index=int(doc_idx), relevance_score=float(score))
+                if request.return_documents:
+                    item.document = CohereDocument(text=original_docs[int(doc_idx)])
+                results.append(item)
+
+            cohere_response = CohereRerankResponse(results=results)
+            payload = _filter_none_values(cohere_response.model_dump())
+            return JSONResponse(content=payload)
+
         # Convert Cohere request to internal format
         internal_request = convert_to_internal_request(request)
 
@@ -134,6 +188,8 @@ async def rerank_v1(request: CohereRerankRequest, service: RerankingService = De
 
         return JSONResponse(content=payload)
 
+    except HTTPException:
+        raise
     except ValueError as e:
         raise HTTPException(status_code=400, detail=f"Invalid input: {str(e)}")
     except RuntimeError as e:

--- a/app/routers/openai_router.py
+++ b/app/routers/openai_router.py
@@ -25,6 +25,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from ..backends.base import BackendManager
+from ..config import settings as app_settings
 from ..models.requests import EmbedRequest, RerankRequest
 from ..models.responses import EmbedResponse
 from ..services.reranking_service import RerankingService
@@ -345,7 +346,12 @@ async def create_embeddings(
         )
 
         # 🔄 Convert enhanced OpenAI request to internal MLX format
-        internal_request = EmbedRequest(texts=texts, normalize=normalize, batch_size=batch_size)
+        internal_request = EmbedRequest(
+            texts=texts,
+            normalize=normalize,
+            batch_size=batch_size,
+            max_tokens_override=max_tokens,
+        )
 
         # ⚡ Generate embeddings using Apple MLX magic with enhanced config!
         # Use the global embedding service with dynamic configuration
@@ -359,7 +365,7 @@ async def create_embeddings(
 
         # 🔄 Optionally adjust dimensions if requested
         vectors: List[List[float]] = mlx_result.vectors
-        target_dims = request.dimensions
+        target_dims = request.dimensions if app_settings.embedding_send_dim else None
         if target_dims is not None and target_dims > 0:
             adjusted: List[List[float]] = []
             for v in vectors:

--- a/app/services/embedding_service.py
+++ b/app/services/embedding_service.py
@@ -158,29 +158,42 @@ class EmbeddingService:
             recommended_max_tokens = 2048
             absolute_max_tokens = 8192
 
-        # 사용자 오버라이드 적용
+        # Apply token limit override with explicit priority:
+        # 1) per-request override
+        # 2) env-configured default override (LightRAG parity: EMBEDDING_TOKEN_LIMIT)
+        # 3) model metadata recommended limit
         max_tokens = recommended_max_tokens
-        if request.max_tokens_override:
-            if request.max_tokens_override > absolute_max_tokens:
+
+        override = request.max_tokens_override
+        override_source = "request"
+        if override is None:
+            override = getattr(self.config, "default_max_tokens_override", None)
+            override_source = "settings"
+
+        # Treat non-positive overrides as disabled/unset.
+        if override is not None and int(override) <= 0:
+            override = None
+
+        if override is not None:
+            override_int = int(override)
+            if override_int > absolute_max_tokens:
                 logger.warning(
-                    f"⚠️  max_tokens_override ({request.max_tokens_override}) exceeds absolute limit "
-                    f"({absolute_max_tokens}), using absolute limit"
+                    f"⚠️  max_tokens_override ({override_int}) exceeds absolute limit "
+                    f"({absolute_max_tokens}), clamping to absolute limit"
                 )
                 max_tokens = absolute_max_tokens
             else:
-                max_tokens = request.max_tokens_override
-                logger.info(
-                    f"🔧 Using user-specified max_tokens_override: {max_tokens} "
-                    f"(recommended: {recommended_max_tokens})"
-                )
-
-        # 사용자 오버라이드가 절대 한도를 초과하는 경우 오류 발생
-        if request.max_tokens_override and request.max_tokens_override > absolute_max_tokens:
-            raise ValueError(
-                f"max_tokens_override ({request.max_tokens_override}) exceeds absolute maximum "
-                f"({absolute_max_tokens}) for model {model_name}"
-            )
-            max_tokens = absolute_max_tokens
+                max_tokens = override_int
+                if override_source == "request":
+                    logger.info(
+                        f"🔧 Using user-specified max_tokens_override: {max_tokens} "
+                        f"(recommended: {recommended_max_tokens})"
+                    )
+                else:
+                    logger.info(
+                        f"🔧 Using default max_tokens_override from settings: {max_tokens} "
+                        f"(recommended: {recommended_max_tokens})"
+                    )
 
         try:
             # 🚀 개선된 텍스트 처리 엔진 사용 (설정 기본값 적용)

--- a/app/services/reranking_service.py
+++ b/app/services/reranking_service.py
@@ -102,6 +102,23 @@ class RerankingService:
 
             raise RuntimeError(error_msg) from e
 
+    async def compute_relevance_scores(self, query: str, passages: List[str]) -> List[float]:
+        """Compute raw relevance scores aligned to the input passages.
+
+        This is useful for advanced routing (e.g. rerank chunking/aggregation) where the
+        caller needs scores for *all* inputs and wants to apply its own top-k semantics.
+        """
+        # Mirror rerank_passages() behavior: treat backend readiness issues as service errors.
+        if not self.backend_manager.is_available():
+            raise RuntimeError("No backend available for reranking")
+
+        try:
+            return await self._compute_relevance_scores(query=query, passages=passages)
+        except ValueError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"Failed to compute relevance scores: {str(e)}") from e
+
     async def _compute_relevance_scores(self, query: str, passages: List[str]) -> List[float]:
         """
         Compute relevance scores for query-passage pairs.

--- a/app/utils/rerank_chunking.py
+++ b/app/utils/rerank_chunking.py
@@ -1,0 +1,123 @@
+"""
+Utilities for document chunking and score aggregation for reranking.
+
+This is intentionally dependency-free and uses the project's existing heuristic:
+1 token ~= 4 characters.
+"""
+
+from __future__ import annotations
+
+from typing import List, Literal, Tuple
+
+
+def chunk_documents(
+    documents: List[str],
+    max_tokens: int,
+    overlap_tokens: int = 32,
+) -> Tuple[List[str], List[int]]:
+    """Chunk documents into overlapping windows based on an approximate token budget.
+
+    Args:
+        documents: List of document strings to chunk.
+        max_tokens: Maximum tokens per chunk (approximate).
+        overlap_tokens: Overlap between chunks in tokens (approximate).
+
+    Returns:
+        (chunked_documents, doc_indices)
+        - chunked_documents: the produced chunks (may be longer than input list)
+        - doc_indices: maps each chunk index back to its original document index
+    """
+    if max_tokens <= 0:
+        raise ValueError("max_tokens must be >= 1")
+
+    # Clamp overlap to guarantee progress. If overlap >= max_tokens, the loop can hang.
+    if overlap_tokens >= max_tokens:
+        overlap_tokens = max(0, max_tokens - 1)
+
+    max_chars = max_tokens * 4
+    overlap_chars = overlap_tokens * 4
+
+    chunked_docs: List[str] = []
+    doc_indices: List[int] = []
+
+    for doc_idx, doc in enumerate(documents):
+        if doc is None:
+            doc = ""
+
+        if len(doc) <= max_chars:
+            chunked_docs.append(doc)
+            doc_indices.append(doc_idx)
+            continue
+
+        start = 0
+        doc_len = len(doc)
+        while start < doc_len:
+            end = min(start + max_chars, doc_len)
+            slice_ = doc[start:end]
+
+            actual_end = end
+            # Try to preserve word boundary when we're not at the end of the document.
+            if end < doc_len:
+                last_space = slice_.rfind(" ")
+                # Only cut on a boundary if it doesn't shrink too aggressively.
+                if last_space >= 0 and last_space > int(max_chars * 0.8):
+                    actual_end = start + last_space
+                    slice_ = doc[start:actual_end]
+
+            if actual_end <= start:
+                # Defensive: ensure progress even in pathological cases.
+                actual_end = end
+                slice_ = doc[start:actual_end]
+
+            chunked_docs.append(slice_)
+            doc_indices.append(doc_idx)
+
+            if actual_end >= doc_len:
+                break
+
+            next_start = actual_end - overlap_chars
+            if next_start <= start:
+                next_start = actual_end
+            start = next_start
+
+    return chunked_docs, doc_indices
+
+
+def aggregate_scores(
+    scores: List[float],
+    doc_indices: List[int],
+    num_docs: int,
+    aggregation: Literal["max"] = "max",
+) -> List[tuple[int, float]]:
+    """Aggregate chunk-level scores back to original document-level scores.
+
+    Args:
+        scores: Chunk-level scores aligned by chunk index.
+        doc_indices: Maps each chunk index to original document index.
+        num_docs: Number of original documents.
+        aggregation: Aggregation strategy. Only "max" is supported.
+
+    Returns:
+        List of (doc_index, aggregated_score) sorted by score desc then index asc.
+    """
+    if aggregation != "max":
+        raise ValueError("Only aggregation='max' is supported")
+    if num_docs < 0:
+        raise ValueError("num_docs must be >= 0")
+
+    best: List[float | None] = [None] * num_docs
+
+    limit = min(len(scores), len(doc_indices))
+    for chunk_idx in range(limit):
+        doc_idx = doc_indices[chunk_idx]
+        if doc_idx < 0 or doc_idx >= num_docs:
+            continue
+        s = float(scores[chunk_idx])
+        cur = best[doc_idx]
+        if cur is None or s > cur:
+            best[doc_idx] = s
+
+    aggregated: List[tuple[int, float]] = [(i, s) for i, s in enumerate(best) if s is not None]
+    aggregated.sort(key=lambda x: (-x[1], x[0]))
+    return aggregated
+

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -72,7 +72,36 @@ curl -X POST "http://localhost:9000/embed" \
   -d '{"inputs": ["test"]}'
 ```
 
-### 2. API 호환성 테스트 실패
+### 2. MLX reranker 로딩 실패 (quant_method 오류)
+
+**문제 증상 (로그 예시):**
+```
+Failed to load CrossEncoder model 'vserifsaglam/Qwen3-Reranker-4B-4bit-MLX':
+The model's quantization config ... has no `quant_method` attribute
+```
+
+**원인:**
+- `RERANKER_BACKEND=auto`는 **reranker에서 Torch를 기본 선택**합니다.
+- MLX 전용 모델(`...-MLX`)을 Torch CrossEncoder로 로딩하면 실패합니다.
+
+**해결 방법:**
+1. **MLX reranker 사용 (Apple Silicon):**
+```bash
+# .env
+RERANKER_BACKEND=mlx
+RERANKER_MODEL_NAME=vserifsaglam/Qwen3-Reranker-4B-4bit-MLX
+
+# (선택) 기본 HF 캐시에 미리 다운로드
+./download-rerank-model.sh
+```
+2. **Torch reranker 유지:**
+```bash
+RERANKER_BACKEND=torch
+RERANKER_MODEL_ID=cross-encoder/ms-marco-MiniLM-L-6-v2
+```
+3. **서비스 재시작 후 /health 또는 /api/v1/rerank 확인**
+
+### 3. API 호환성 테스트 실패
 
 **문제 증상:**
 ```bash
@@ -107,7 +136,7 @@ curl http://localhost:9000/health/
 tail -f server.log  # 백그라운드 서버인 경우
 ```
 
-### 3. 포트 충돌 문제
+### 4. 포트 충돌 문제
 
 **문제 증상:**
 ```
@@ -137,7 +166,7 @@ embed-rerank --port 8080
 python -m uvicorn app.main:app --port 8080
 ```
 
-### 4. 모델 로딩 실패
+### 5. 모델 로딩 실패
 
 **문제 증상:**
 ```
@@ -165,7 +194,7 @@ tokenizer = AutoTokenizer.from_pretrained("mlx-community/Qwen3-Embedding-4B-4bit
 4. **디스크 공간 확인:**
 모델은 약 2.3GB의 공간이 필요합니다.
 
-### 5. Apple Silicon이 아닌 환경
+### 6. Apple Silicon이 아닌 환경
 
 **문제 증상:**
 ```
@@ -187,7 +216,7 @@ curl http://localhost:9000/health/
 - Intel Mac (PyTorch MPS): 10-50ms  
 - Other (PyTorch CPU): 100-500ms
 
-### 6. 가상환경 문제
+### 7. 가상환경 문제
 
 **문제 증상:**
 ```

--- a/tests/test_openai_embeddings_options.py
+++ b/tests/test_openai_embeddings_options.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+class _FakeEmbeddingService:
+    def __init__(self, vectors: Optional[List[List[float]]] = None):
+        self.last_request = None
+        self._vectors = vectors or [[0.0, 1.0, 2.0, 3.0]]
+
+    async def embed_texts(self, request):  # noqa: ANN001
+        from app.models.responses import EmbedResponse, EmbeddingVector
+
+        self.last_request = request
+        vectors = self._vectors
+        embeddings = [EmbeddingVector(embedding=vectors[0], index=0, text="x")]
+        return EmbedResponse(
+            embeddings=embeddings,
+            vectors=vectors,
+            dim=len(vectors[0]),
+            backend="fake",
+            device="cpu",
+            processing_time=0.0,
+            model_info="fake",
+            usage={"total_texts": 1, "total_tokens": 1},
+            timestamp=datetime.now(),
+            num_texts=1,
+        )
+
+
+@pytest.fixture
+def client_and_service():
+    from app.routers import openai_router
+
+    app = FastAPI()
+    app.include_router(openai_router.router)
+
+    openai_router.set_backend_manager(object())
+    svc = _FakeEmbeddingService()
+    openai_router.set_embedding_service(svc)
+
+    with TestClient(app) as client:
+        yield client, svc, openai_router
+
+
+def test_openai_embeddings_maps_max_tokens_per_text_to_internal_override(client_and_service):
+    client, svc, _openai_router = client_and_service
+    resp = client.post(
+        "/v1/embeddings",
+        json={"input": "hello", "model": "text-embedding-ada-002", "max_tokens_per_text": 123},
+    )
+    assert resp.status_code == 200
+    assert svc.last_request is not None
+    assert getattr(svc.last_request, "max_tokens_override", None) == 123
+
+
+def test_openai_embeddings_dimensions_gate_respected(client_and_service, monkeypatch):
+    client, svc, openai_router = client_and_service
+
+    # Disable honoring `dimensions` and ensure vector size is unchanged.
+    monkeypatch.setattr(openai_router.app_settings, "embedding_send_dim", False, raising=False)
+    resp = client.post("/v1/embeddings", json={"input": "hello", "model": "text-embedding-ada-002", "dimensions": 2})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["data"][0]["embedding"]) == 4
+
+    # Enable honoring `dimensions` and ensure vector is truncated/padded.
+    monkeypatch.setattr(openai_router.app_settings, "embedding_send_dim", True, raising=False)
+    resp2 = client.post("/v1/embeddings", json={"input": "hello", "model": "text-embedding-ada-002", "dimensions": 2})
+    assert resp2.status_code == 200
+    data2 = resp2.json()
+    assert len(data2["data"][0]["embedding"]) == 2

--- a/tests/test_rerank_chunking.py
+++ b/tests/test_rerank_chunking.py
@@ -1,0 +1,24 @@
+from app.utils.rerank_chunking import aggregate_scores, chunk_documents
+
+
+def test_chunk_documents_splits_and_tracks_indices():
+    docs = ["a" * 5000]
+    chunks, indices = chunk_documents(docs, max_tokens=480)  # ~1920 chars per chunk
+    assert len(chunks) > 1
+    assert len(chunks) == len(indices)
+    assert all(i == 0 for i in indices)
+
+
+def test_chunk_documents_overlap_clamp_does_not_hang():
+    docs = ["hello world " * 200]
+    chunks, indices = chunk_documents(docs, max_tokens=10, overlap_tokens=10)
+    assert len(chunks) >= 1
+    assert len(chunks) == len(indices)
+
+
+def test_aggregate_scores_max_and_deterministic_sort():
+    scores = [0.1, 0.9, 0.5, 0.5]
+    doc_indices = [0, 0, 1, 2]
+    aggregated = aggregate_scores(scores, doc_indices, num_docs=3, aggregation="max")
+    assert aggregated == [(0, 0.9), (1, 0.5), (2, 0.5)]
+

--- a/tests/test_settings_aliases.py
+++ b/tests/test_settings_aliases.py
@@ -1,0 +1,24 @@
+def test_embedding_token_limit_alias(monkeypatch):
+    from app.config import Settings
+
+    monkeypatch.setenv("EMBEDDING_TOKEN_LIMIT", "1234")
+    s = Settings()
+    assert s.default_max_tokens_override == 1234
+
+
+def test_embedding_send_dim_alias(monkeypatch):
+    from app.config import Settings
+
+    monkeypatch.setenv("EMBEDDING_SEND_DIM", "false")
+    s = Settings()
+    assert s.embedding_send_dim is False
+
+
+def test_rerank_chunking_envs(monkeypatch):
+    from app.config import Settings
+
+    monkeypatch.setenv("RERANK_ENABLE_CHUNKING", "true")
+    monkeypatch.setenv("RERANK_MAX_TOKENS_PER_DOC", "480")
+    s = Settings()
+    assert s.rerank_enable_chunking is True
+    assert s.rerank_max_tokens_per_doc == 480

--- a/tools/download-rerank-model.sh
+++ b/tools/download-rerank-model.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+VENV_PY="/Users/bear8203/Works/Development Projects/embed-rerank/.venv/bin/python"
+
+if [ ! -x "$VENV_PY" ]; then
+  echo "❌ venv python not found: $VENV_PY"
+  echo "   Create the venv first (e.g., python -m venv .venv) and install deps."
+  exit 1
+fi
+
+"$VENV_PY" -c "from huggingface_hub import snapshot_download; snapshot_download('vserifsaglam/Qwen3-Reranker-4B-4bit-MLX', resume_download=True)"
+
+echo "✅ Rerank model download complete"


### PR DESCRIPTION
LightRAG recently added new embedding/rerank options via env vars. embed-rerank previously ignored or didn’t correctly apply these options, which could break LightRAG compatibility. This PR adds env parity and wires the options into the OpenAI embeddings and Cohere rerank flows while keeping default behavior unchanged when options are unset.

## What Changed
- Config/env parity (config.py)
  - Added env aliases:
  - `EMBEDDING_TOKEN_LIMIT` -> `default_max_tokens_override` (alias of `DEFAULT_MAX_TOKENS_OVERRIDE` )
  - `EMBEDDING_SEND_DIM` -> `embedding_send_dim` (gate for honoring OpenAI `dimensions` )
  - `RERANK_ENABLE_CHUNKING` -> `rerank_enable_chunking`
  - `RERANK_MAX_TOKENS_PER_DOC` -> `rerank_max_tokens_per_doc` (min 1, default 4096)
- Embeddings (openai_router.py, embedding_service.py)
  - `/v1/embeddings` now forwards `max_tokens_per_text` to internal `EmbedRequest.max_tokens_override`
  - Token limit selection now follows: request override > env default override > model recommended
Overrides are clamped to absolute max (warn + clamp; no error)
  - `dimensions` pad/truncate is now gated by `EMBEDDING_SEND_DIM` (default: enabled, preserving current behavior)
- Cohere rerank chunking (cohere_router.py, rerank_chunking.py)
  - Optional server-side document chunking controlled by env
  - Chunk-level scoring with doc-level aggregation ( `max` ), deterministic sort (score desc, index asc)
  - `top_n` is applied after aggregation (document-level semantics)
  - Guardrail: if chunking produces more than `MAX_PASSAGES_PER_RERANK` , return 400 with guidance
  - Cohere endpoints now also prefer the dedicated cross-encoder backend when configured (main.py)
- Docs
  - Updated `.env.example` and README.md with the new LightRAG parity options
  
## Backward Compatibility
- No API request/response schema changes.
- Defaults remain unchanged when new env vars are unset.
- Cohere chunking is disabled by default.
- OpenAI `dimensions` behavior remains enabled by default (same as before).

## Tests
- Added/updated tests:
  - test_settings_aliases.py
  - test_openai_embeddings_options.py
  - test_rerank_chunking.py
- Ran locally:
  - test_openai_embeddings_options.py
  - test_ci_quick.py